### PR TITLE
feat: Added Window.fromPid() method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -32,6 +32,7 @@ export class Window {
   static console(): Window | null
   static fromProcess(name: string): Promise<Window>
   static fromTitle(name: string): Promise<Window>
+  static fromPid(pid: number): Promise<Window>
   static all(): Promise<Array<Window>>
   screenshot(): Screenshot
   position(): Coordinates

--- a/src/window/finder.rs
+++ b/src/window/finder.rs
@@ -10,6 +10,7 @@ use windows_sys::Win32::{Foundation::*, System::Threading::*, UI::WindowsAndMess
 pub enum Kind {
   ProcessName,
   WindowTitle,
+  ProcessId,
 }
 
 pub struct Finder {
@@ -97,6 +98,17 @@ unsafe extern "system" fn window_finder_proc(hwnd: isize, lparam: isize) -> i32 
       {
         (*ptr).output.replace(hwnd);
 
+        0
+      } else {
+        1
+      }
+    }
+
+    Kind::ProcessId => {
+      CloseHandle(process);
+
+      if (*ptr).requested_name.parse::<u32>().unwrap() == proc_id {
+        (*ptr).output.replace(hwnd);
         0
       } else {
         1

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -82,6 +82,11 @@ impl Window {
     AsyncTask::new(Collector::new())
   }
 
+  #[napi(js_name = "fromPid")]
+  pub fn from_pid(pid: u32) -> AsyncTask<Finder> {
+    AsyncTask::new(Finder::new(finder::Kind::ProcessId, pid.to_string()))
+  }
+
   #[napi]
   pub fn screenshot(&self) -> Screenshot {
     unsafe {


### PR DESCRIPTION
It's me again.
I've added a `Window.fromPid()` method, which makes it a easier/more reliable to find your window, for example:
```ts
const { spawn } = require('node:child_process');
const { Window, keyboard } = require('js-macro');

const process = spawn('notepad.exe');

setTimeout(async () => {
  let notepad = await Window.fromPid(process.pid);

  if (!notepad) {
    return console.error('error: cannot find notepad :(');
  }

  notepad.focus();

  keyboard.type('Hello, World!');
}, 1000);
```

> Important note! This is the first time ever I wrote some Rust code. It probably could have been better, but I couldn't find a way to accept a `string` and `u32` at the same time for the constructor.