### PR TITLE
fix: repl.repl can be undefined

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -27,7 +27,7 @@ const cleanup: () => void = mod.cleanup;
 
 process.on('exit', cleanup);
 
-if (repl) {
+if (repl?.repl) {
   repl.repl.on('exit', cleanup);
 }
 


### PR DESCRIPTION
When I use this module it always crashes because `repl.repl` is undefined.
To be honest, I'm not quite sure what it's meant for.